### PR TITLE
Fix documentation for SplayTree#traverse_

### DIFF
--- a/tools/v8/splaytree.js
+++ b/tools/v8/splaytree.js
@@ -284,7 +284,7 @@ SplayTree.prototype.splay_ = function(key) {
 
 
 /**
- * Performs a preorder traversal of the tree.
+ * Performs a level-order traversal of the tree.
  *
  * @param {function(SplayTree.Node)} f Visitor function.
  * @private


### PR DESCRIPTION
Hey, I randomly stumbled upon this project and was navigating the code out of curiosity. I ran into your implementation of a SplayTree and noticed there is either a problem in the documentation or in the implementation, depends on what your intention was.

It seems that  `SplayTree#traverse` is documented as a pre-order traversal but it is implemented using an array as a queue of nodes to visit, so it is in fact a level-order bfs traversal.
